### PR TITLE
Updating function "BuildUriForListRecords"

### DIFF
--- a/AirtableApiClient/AirtableBase.cs
+++ b/AirtableApiClient/AirtableBase.cs
@@ -275,7 +275,7 @@ namespace AirtableApiClient
             IEnumerable<Sort> sort,
             string view)
         {
-            var uriBuilder = new UriBuilder(AIRTABLE_API_URL + BaseId + "/" + HttpUtility.UrlEncode(tableName));
+            var uriBuilder = new UriBuilder(AIRTABLE_API_URL + BaseId + "/" + tableName);
 
             var query = HttpUtility.ParseQueryString(uriBuilder.Query);
 


### PR DESCRIPTION
Found Error while retrieving records. on base of Debugging Removing "HttpUtility.UrlEncode function for TableName" on line no 278

Reason:
Its adding a + sign between the table name if it contains a space that puts an error when uri is made. If we leave it blank it does automatically put %20 as space.