### PR TITLE
Remove index when URL encoding fields[]

### DIFF
--- a/AirtableApiClient/QueryParamHelper.cs
+++ b/AirtableApiClient/QueryParamHelper.cs
@@ -87,7 +87,7 @@ namespace AirtableApiClient
                 {
                     toInsert = "&";
                 }
-                string param = $"fields[{i}]";
+                string param = "fields[]";
                 flattenFieldsParam += $"{toInsert}{HttpUtility.UrlEncode(param)}={HttpUtility.UrlEncode(fieldName)}";
                 i++;
             }


### PR DESCRIPTION
The AirTable API examples don't include an index when requesting fields. From personal experience I have found that a GET request fails when > 21 indexed fields are supplied, and I have received advice from AirTable support to omit array indexes from the query.