### PR TITLE
Escape table name

### DIFF
--- a/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
+++ b/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
@@ -39,7 +39,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AirtableApiClient, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="AirtableApiClient, Version=1.1.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\AirtableApiClient\bin\Release\AirtableApiClient.dll</HintPath>
     </Reference>

--- a/AirtableApiClient.Tests/AtApiClientTests.cs
+++ b/AirtableApiClient.Tests/AtApiClientTests.cs
@@ -30,10 +30,10 @@ namespace AirtableApiClient.Tests
     [TestClass]
     public class AtApiClientTests
     {
-        const string APPLICATION_ID = "app1234567890ABCD";  // fake app id for tests
-        const string API_KEY = "key1234567890ABCD";         // fake airtable api key for tests
-        const string TABLE_NAME = "Artists";                // fake table name for tests
-        readonly string BASE_URL = $"https://api.airtable.com/v0/{APPLICATION_ID}/{Uri.EscapeUriString(TABLE_NAME)}";
+        const string APPLICATION_ID = "app1234567890ABCD";                          // fake app id for tests
+        const string API_KEY = "key1234567890ABCD";                                 // fake airtable api key for tests
+        const string TABLE_NAME = ":/?#[]@!$&'()*+,;= Best Artists\\ %2F -._~";     // fake table name for tests
+        readonly string BASE_URL = $"https://api.airtable.com/v0/{APPLICATION_ID}/{Uri.EscapeDataString(TABLE_NAME)}";
 
         static private AirtableBase airtableBase;
         private FakeResponseHandler fakeResponseHandler;

--- a/AirtableApiClient/AirtableApiClient.csproj
+++ b/AirtableApiClient/AirtableApiClient.csproj
@@ -21,7 +21,7 @@
   <PackageIcon>airtable_64x64.png</PackageIcon>
   <PackageLicenseFile>LICENSE</PackageLicenseFile>
   <PackageTags>Airtable database spreadsheet organize Kanban API</PackageTags>
-  <PackageReleaseNotes>Url Encode table name. Bug discovered and code contributed by Titouan C.</PackageReleaseNotes>
+  <PackageReleaseNotes>Fixed bug introduced by last release (1.1.3) where table names with spaces were no longer encoded correctly.</PackageReleaseNotes>
   <Description>AirtableApiClient is the C-Sharp client of the public APIs of Airtable. It facilitates the usage of Airtable APIs without having to worry about interfacing with raw HTTP.</Description>
   <RepositoryUrl>https://github.com/ngocnicholas/airtable.net</RepositoryUrl>
   <RepositoryType>git</RepositoryType>

--- a/AirtableApiClient/AirtableBase.cs
+++ b/AirtableApiClient/AirtableBase.cs
@@ -163,7 +163,7 @@ namespace AirtableApiClient
                 throw new ArgumentException("Record ID cannot be null", "id");
             }
 
-            string uriStr = AIRTABLE_API_URL + BaseId + "/" + HttpUtility.UrlEncode(tableName) + "/" + id;
+            string uriStr = AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName) + "/" + id;
             var request = new HttpRequestMessage(HttpMethod.Get, uriStr);
             var response = await httpClientWithRetries.SendAsync(request);
             AirtableApiException error = await CheckForAirtableException(response);
@@ -258,7 +258,7 @@ namespace AirtableApiClient
                 throw new ArgumentException("Record ID cannot be null", "id");
             }
 
-            string uriStr = AIRTABLE_API_URL + BaseId + "/" + HttpUtility.UrlEncode(tableName) + "/" + id;
+            string uriStr = AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName) + "/" + id;
             var request = new HttpRequestMessage(HttpMethod.Delete, uriStr);
             var response = await httpClientWithRetries.SendAsync(request);
             AirtableApiException error = await CheckForAirtableException(response);
@@ -360,7 +360,7 @@ namespace AirtableApiClient
             IEnumerable<Sort> sort,
             string view)
         {
-            var uriBuilder = new UriBuilder(AIRTABLE_API_URL + BaseId + "/" + HttpUtility.UrlEncode(tableName));
+            var uriBuilder = new UriBuilder(AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName));
 
             if (!string.IsNullOrEmpty(offset))
             {
@@ -451,7 +451,7 @@ namespace AirtableApiClient
                 throw new ArgumentException("Table Name cannot be null", "tableName");
             }
 
-            string uriStr = AIRTABLE_API_URL + BaseId + "/" + HttpUtility.UrlEncode(tableName) + "/";
+            string uriStr = AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName) + "/";
             HttpMethod httpMethod;
             switch (operationType)
             {
@@ -503,7 +503,7 @@ namespace AirtableApiClient
             {
                 throw new ArgumentException("Table Name cannot be null", "tableName");
             }
-            string uriStr = AIRTABLE_API_URL + BaseId + "/" + HttpUtility.UrlEncode(tableName) + "/";
+            string uriStr = AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName) + "/";
             var request = new HttpRequestMessage(method, uriStr);
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await httpClientWithRetries.SendAsync(request);

--- a/AirtableApiClient/Properties/AssemblyInfo.cs
+++ b/AirtableApiClient/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.3")]
-[assembly: AssemblyFileVersion("1.1.3")]
+[assembly: AssemblyVersion("1.1.4")]
+[assembly: AssemblyFileVersion("1.1.4")]
 [assembly: InternalsVisibleTo("AirtableApiClient.Tests")]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Airtable by consuming what Airtable public APIs have to offer programmatically s
 Update Record, Replace Record, Delete Record.
 
 # Installation
-Install the latest nuget package Airtable.1.1.3.nupkg
+Install the latest nuget package Airtable.1.1.4.nupkg
 
 ## Requirements
 


### PR DESCRIPTION
Call Uri.EscapeDataString for table name so that all characters will be encoded correctly.