### PR TITLE
Added ConfigureAwait(false) on async await calls

### DIFF
--- a/AirtableApiClient/AirtableBase.cs
+++ b/AirtableApiClient/AirtableBase.cs
@@ -95,14 +95,14 @@ namespace AirtableApiClient
             string view = null)
         {
             HttpResponseMessage response = await ListRecordsInternal(tableName, offset, fields, filterByFormula,
-                maxRecords, pageSize, sort, view);
-            AirtableApiException error = await CheckForAirtableException(response);
+                maxRecords, pageSize, sort, view).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableListRecordsResponse(error);
             }
 
-            var responseBody = await response.Content.ReadAsStringAsync();
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             AirtableRecordList recordList = JsonConvert.DeserializeObject<AirtableRecordList>(responseBody);
             return new AirtableListRecordsResponse(recordList);
         }
@@ -128,14 +128,14 @@ namespace AirtableApiClient
             string view = null)
         {
             HttpResponseMessage response = await ListRecordsInternal(tableName, offset, fields, filterByFormula,
-                maxRecords, pageSize, sort, view);
-            AirtableApiException error = await CheckForAirtableException(response);
+                maxRecords, pageSize, sort, view).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableListRecordsResponse<T>(error);
             }
 
-            var responseBody = await response.Content.ReadAsStringAsync();
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             AirtableRecordList<T> recordList = JsonConvert.DeserializeObject<AirtableRecordList<T>>(responseBody);
             return new AirtableListRecordsResponse<T>(recordList);
         }
@@ -165,13 +165,13 @@ namespace AirtableApiClient
 
             string uriStr = AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName) + "/" + id;
             var request = new HttpRequestMessage(HttpMethod.Get, uriStr);
-            var response = await httpClientWithRetries.SendAsync(request);
-            AirtableApiException error = await CheckForAirtableException(response);
+            var response = await httpClientWithRetries.SendAsync(request).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableRetrieveRecordResponse(error);
             }
-            var responseBody = await response.Content.ReadAsStringAsync();
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var airtableRecord = JsonConvert.DeserializeObject<AirtableRecord>(responseBody);
 
             return new AirtableRetrieveRecordResponse(airtableRecord);
@@ -203,13 +203,13 @@ namespace AirtableApiClient
 
             string uriStr = AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName) + "/" + id;
             var request = new HttpRequestMessage(HttpMethod.Get, uriStr);
-            var response = await httpClientWithRetries.SendAsync(request);
-            AirtableApiException error = await CheckForAirtableException(response);
+            var response = await httpClientWithRetries.SendAsync(request).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableRetrieveRecordResponse<T>(error);
             }
-            var responseBody = await response.Content.ReadAsStringAsync();
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             AirtableRecord<T> airtableRecord = JsonConvert.DeserializeObject<AirtableRecord<T>>(responseBody);
 
             return new AirtableRetrieveRecordResponse<T>(airtableRecord);
@@ -230,7 +230,7 @@ namespace AirtableApiClient
             bool typecast = false)
         {
             Task<AirtableCreateUpdateReplaceRecordResponse> task = CreateUpdateReplaceRecord(tableName, fields, OperationType.CREATE, typecast: typecast);
-            var response = await task;
+            var response = await task.ConfigureAwait(false);
             return response;
         }
 
@@ -250,7 +250,7 @@ namespace AirtableApiClient
             bool typeCast = false)
         {
             Task<AirtableCreateUpdateReplaceRecordResponse> task = CreateUpdateReplaceRecord(tableName, fields, OperationType.UPDATE, id, typeCast);
-            var response = await task;
+            var response = await task.ConfigureAwait(false);
             return response;
         }
 
@@ -270,7 +270,7 @@ namespace AirtableApiClient
             bool typeCast = false)
         {
             Task<AirtableCreateUpdateReplaceRecordResponse> task = CreateUpdateReplaceRecord(tableName, fields, OperationType.REPLACE, id, typeCast);
-            return (await task);
+            return (await task.ConfigureAwait(false));
         }
 
 
@@ -298,13 +298,13 @@ namespace AirtableApiClient
 
             string uriStr = AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName) + "/" + id;
             var request = new HttpRequestMessage(HttpMethod.Delete, uriStr);
-            var response = await httpClientWithRetries.SendAsync(request);
-            AirtableApiException error = await CheckForAirtableException(response);
+            var response = await httpClientWithRetries.SendAsync(request).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableDeleteRecordResponse(error);
             }
-            var responseBody = await response.Content.ReadAsStringAsync();
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var deletedRecord = JsonConvert.DeserializeObject<AirtableDeletedRecord>(responseBody);
             return new AirtableDeleteRecordResponse(deletedRecord.Deleted, deletedRecord.Id);
         }
@@ -325,7 +325,7 @@ namespace AirtableApiClient
         {
             var json = JsonConvert.SerializeObject(new { records = fields, typecast = typecast }, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             Task<AirtableCreateUpdateReplaceMultipleRecordsResponse> task = CreateUpdateReplaceMultipleRecords(tableName, HttpMethod.Post, json);
-            var response = await task;
+            var response = await task.ConfigureAwait(false);
             return response;
 
         }
@@ -346,7 +346,7 @@ namespace AirtableApiClient
         {
             var json = JsonConvert.SerializeObject(new { records = idFields, typecast = typecast }, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             Task<AirtableCreateUpdateReplaceMultipleRecordsResponse> task = CreateUpdateReplaceMultipleRecords(tableName, new HttpMethod("PATCH"), json);
-            return (await task);
+            return (await task.ConfigureAwait(false));
         }
 
 
@@ -365,7 +365,7 @@ namespace AirtableApiClient
         {
             var json = JsonConvert.SerializeObject(new { records = idFields, typecast = typecast }, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             Task<AirtableCreateUpdateReplaceMultipleRecordsResponse> task = CreateUpdateReplaceMultipleRecords(tableName, HttpMethod.Put, json);
-            return (await task);
+            return (await task.ConfigureAwait(false));
         }
 
         //----------------------------------------------------------------------------
@@ -512,14 +512,14 @@ namespace AirtableApiClient
             var json = JsonConvert.SerializeObject(fieldsAndTypecast, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             var request = new HttpRequestMessage(httpMethod, uriStr);
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            var response = await httpClientWithRetries.SendAsync(request);
+            var response = await httpClientWithRetries.SendAsync(request).ConfigureAwait(false);
 
-            AirtableApiException error = await CheckForAirtableException(response);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableCreateUpdateReplaceRecordResponse(error);
             }
-            var responseBody = await response.Content.ReadAsStringAsync();
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var airtableRecord = JsonConvert.DeserializeObject<AirtableRecord>(responseBody);
 
             return new AirtableCreateUpdateReplaceRecordResponse(airtableRecord);
@@ -544,14 +544,14 @@ namespace AirtableApiClient
             string uriStr = AIRTABLE_API_URL + BaseId + "/" + Uri.EscapeDataString(tableName) + "/";
             var request = new HttpRequestMessage(method, uriStr);
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            var response = await httpClientWithRetries.SendAsync(request);
+            var response = await httpClientWithRetries.SendAsync(request).ConfigureAwait(false);
 
-            AirtableApiException error = await CheckForAirtableException(response);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableCreateUpdateReplaceMultipleRecordsResponse(error);
             }
-            var responseBody = await response.Content.ReadAsStringAsync();
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var recordList = JsonConvert.DeserializeObject<AirtableRecordList>(responseBody);
 
             return new AirtableCreateUpdateReplaceMultipleRecordsResponse(recordList.Records);
@@ -592,7 +592,7 @@ namespace AirtableApiClient
                     return (new AirtableRequestEntityTooLargeException());
 
                 case (System.Net.HttpStatusCode)422:    // There is no HttpStatusCode.InvalidRequest defined in HttpStatusCode Enumeration.
-                    var error = await ReadResponseErrorMessage(response);
+                    var error = await ReadResponseErrorMessage(response).ConfigureAwait(false);
                     return (new AirtableInvalidRequestException(error));
 
                 case (System.Net.HttpStatusCode)429:    // There is no HttpStatusCode.TooManyRequests defined in HttpStatusCode Enumeration.
@@ -614,7 +614,7 @@ namespace AirtableApiClient
 
         private static async Task<string> ReadResponseErrorMessage(HttpResponseMessage response)
         {
-            var content = await response.Content.ReadAsStringAsync();
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(content))
             {
@@ -650,7 +650,7 @@ namespace AirtableApiClient
             }
             var uri = BuildUriForListRecords(tableName, offset, fields, filterByFormula, maxRecords, pageSize, sort, view);
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            return (await httpClientWithRetries.SendAsync(request));
+            return (await httpClientWithRetries.SendAsync(request).ConfigureAwait(false));
         }
 
     }   // end class

--- a/AirtableApiClient/HttpClientWithRetries.cs
+++ b/AirtableApiClient/HttpClientWithRetries.cs
@@ -89,21 +89,21 @@ namespace AirtableApiClient
             // of retries.
             if (request.Content != null)
             {
-                content = await request.Content.ReadAsStringAsync();
+                content = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
 
             int dueTimeDelay = RetryDelayMillisecondsIfRateLimited;
             int retries = 0;
 
-            HttpResponseMessage response = await client.SendAsync(request);
+            HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);
 
             while (response.StatusCode == (HttpStatusCode)429 &&
                 retries < MAX_RETRIES &&
                 !ShouldNotRetryIfRateLimited)
             {
-                await Task.Delay(dueTimeDelay);
+                await Task.Delay(dueTimeDelay).ConfigureAwait(false);
                 var requestRegenerated = RegenerateRequest(request.Method, request.RequestUri, content);
-                response = await client.SendAsync(requestRegenerated);
+                response = await client.SendAsync(requestRegenerated).ConfigureAwait(false);
                 retries++;
                 dueTimeDelay *= 2;
             }


### PR DESCRIPTION
We had trouble to call methods on AirtableBase from synchronous code. The changes in this commit fixed them for us and should not compromise asynchronous calls. See: https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html