### PR TITLE
Update nupkg version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Airtable by consuming what Airtable public APIs have to offer programmatically s
 Update Record, Replace Record, Delete Record.
 
 # Installation
-Install the latest nuget package Airtable.1.2.0.nupkg
+Install the latest nuget package Airtable.1.3.0.nupkg
 
 ## Requirements
 


### PR DESCRIPTION
Now that 1.3.0 is out 🥳, the readme needs to not say to install 1.2.0 anymore