### PR TITLE
Added multitargeting

### DIFF
--- a/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
+++ b/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
+   <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{19EC2479-BBC2-4AD0-818C-B3012893220F}</ProjectGuid>

--- a/AirtableApiClient/AirtableApiClient.csproj
+++ b/AirtableApiClient/AirtableApiClient.csproj
@@ -69,7 +69,7 @@ SDK Version: 7.0.200  </PackageReleaseNotes>
        See: https://markheath.net/post/csproj-conditional-references
    -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net7.0'">
-    <PackageReference Include="System.Text.Json" Version="6.0.8" />
+    <PackageReference Include="System.Text.Json" Version="[6.*,7.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="System.Text.Json" Version="7.0.2" />

--- a/AirtableApiClient/AirtableApiClient.csproj
+++ b/AirtableApiClient/AirtableApiClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <ApplicationIcon />
     <Win32Resource />
@@ -57,8 +57,21 @@ SDK Version: 7.0.200  </PackageReleaseNotes>
     <None Remove="readme.txt" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- I'm doubtful whether this will actually restore functionality for netstandard2.0,
+       however this should be on par with how well this NuGet worked before net7.0 support was 
+       added.
+
+       If netstandard2.0 support does not work and is needed, split the following condition
+       and add appropriate versions.
+
+       (Of course, additional targets, such as net8.0 could also be added likewise.)
+
+       See: https://markheath.net/post/csproj-conditional-references
+   -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net7.0'">
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This PR is intended to solve problems caused by System.Text.Json version 7.x not actually being compatible with Net 6.0 (nor [presumably] older).

I am assuming System.Text.Json 6.x works with netstandard2.0 since I see no issue to the contrary and all tests are passing.
If not, this shouldn't make the solution any worse for them and the solution should be as good as it was for them before this NuGet was revised to use System.Text.Json version 7.x.

(If System.Text.Json 6.x does not work for netstandard2.0, this is beyond the scope of this PR as well as beyond the scope of what I am presently willing or able to fix.  If this is still needed, it may even mean using Newtonsoft.Json as an alternative, which would could add a lot of complication to the codebase.)
