### PR TITLE
Add example code highlighting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Example demonstrating usage of the API to list records:
 
 ----------------------
 
-```
+```cs
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -54,7 +54,7 @@ readonly string appKey = YOUR_APP_KEY_OR_ACCESS_TOKEN;
 ----------------------
 
 
-```
+```cs
 
     string offset = null;
     string errorMessage = null;


### PR DESCRIPTION
Corrected README.md a bit to enable C# syntax highlighting to improve readability.

## Before
![image](https://github.com/ngocnicholas/airtable.net/assets/5685857/d0204cc1-d882-46a4-8ff3-c504817301f8)

## After
![image](https://github.com/ngocnicholas/airtable.net/assets/5685857/880ba759-a7f2-400e-b80b-6eea53d8a8ea)
