### PR TITLE
All async operations are cancellable. AirtableBase accepts a user pro…

### DIFF
--- a/AirtableApiClient.sln
+++ b/AirtableApiClient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2036
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32602.215
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AirtableApiClient", "AirtableApiClient\AirtableApiClient.csproj", "{9A0F05CF-701E-4558-956A-C095FAAC2C91}"
 EndProject

--- a/AirtableApiClient/AirtableBase.cs
+++ b/AirtableApiClient/AirtableBase.cs
@@ -131,7 +131,7 @@ namespace AirtableApiClient
             {
                 return new AirtableGetUserIdAndScopesResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             UserIdAndScopes userIdAndScopes = JsonSerializer.Deserialize<UserIdAndScopes>(responseBody, JsonOptionIgnoreNullValues);
             return new AirtableGetUserIdAndScopesResponse(userIdAndScopes);
         }
@@ -168,13 +168,14 @@ namespace AirtableApiClient
                 returnFieldsByFieldId, includeCommentCount,
                 token
                 ).ConfigureAwait(false);
+
             AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableListRecordsResponse(error);
             }
 
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             AirtableRecordList recordList = JsonSerializer.Deserialize<AirtableRecordList>(responseBody, JsonOptionIgnoreNullValues);
             return new AirtableListRecordsResponse(recordList);
         }
@@ -213,7 +214,7 @@ namespace AirtableApiClient
                 return new AirtableListRecordsResponse<T>(error);
             }
 
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             AirtableRecordList<T> recordList = JsonSerializer.Deserialize<AirtableRecordList<T>>(responseBody);
             return new AirtableListRecordsResponse<T>(recordList);
         }
@@ -244,7 +245,7 @@ namespace AirtableApiClient
             {
                 return new AirtableRetrieveRecordResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var airtableRecord = JsonSerializer.Deserialize<AirtableRecord>(responseBody, JsonOptionIgnoreNullValues);
 
             return new AirtableRetrieveRecordResponse(airtableRecord);
@@ -279,7 +280,7 @@ namespace AirtableApiClient
             {
                 return new AirtableRetrieveRecordResponse<T>(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             AirtableRecord<T> airtableRecord = JsonSerializer.Deserialize<AirtableRecord<T>>(responseBody);
 
             return new AirtableRetrieveRecordResponse<T>(airtableRecord);
@@ -362,7 +363,7 @@ namespace AirtableApiClient
             {
                 return new AirtableDeleteRecordResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var deletedRecord = JsonSerializer.Deserialize<AirtableDeletedRecord>(responseBody);
             return new AirtableDeleteRecordResponse(deletedRecord.Deleted, deletedRecord.Id);
         }
@@ -546,7 +547,7 @@ namespace AirtableApiClient
             {
                 return new AirtableListCommentsResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var commentList = JsonSerializer.Deserialize<CommentList>(responseBody, JsonOptionIgnoreNullValues);
             return new AirtableListCommentsResponse(commentList);
         }
@@ -619,7 +620,7 @@ namespace AirtableApiClient
             {
                 return new AirtableDeleteCommentResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var deletedComment = JsonSerializer.Deserialize<AirtableDeletedRecord>(responseBody);
             return new AirtableDeleteCommentResponse(deletedComment.Deleted, deletedComment.Id);
         }
@@ -641,7 +642,7 @@ namespace AirtableApiClient
             {
                 return new AirtableListWebhooksResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var webhooks = JsonSerializer.Deserialize<Webhooks>(responseBody, JsonOptionIgnoreNullValues);
 
             return new AirtableListWebhooksResponse(webhooks);
@@ -678,7 +679,7 @@ namespace AirtableApiClient
             {
                 return new AirtableListPayloadsResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var payloadList = JsonSerializer.Deserialize<PayloadList>(responseBody, JsonOptionIgnoreNullValues);
 
             return new AirtableListPayloadsResponse(payloadList);
@@ -712,7 +713,7 @@ namespace AirtableApiClient
             {
                 return new AirtableCreateWebhookResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var createWebhookResponse = JsonSerializer.Deserialize<CreateWebhookResponse>(responseBody, JsonOptionIgnoreNullValues);
 
             return new AirtableCreateWebhookResponse(createWebhookResponse);
@@ -745,7 +746,7 @@ namespace AirtableApiClient
                 return new AirtabeEnableOrDisableWebhookNotificationsResponse(error);
             }
 
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             return new AirtabeEnableOrDisableWebhookNotificationsResponse();
         }
 
@@ -771,7 +772,7 @@ namespace AirtableApiClient
             {
                 return new AirtabeRefreshWebhookResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             NotificationExpirationTime exp = JsonSerializer.Deserialize<NotificationExpirationTime>(responseBody, JsonOptionIgnoreNullValues);
             return new AirtabeRefreshWebhookResponse(exp.ExpirationTime);
         }
@@ -945,7 +946,7 @@ namespace AirtableApiClient
             {
                 return new AirtableCreateUpdateReplaceRecordResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var airtableRecord = JsonSerializer.Deserialize<AirtableRecord>(responseBody);
 
             return new AirtableCreateUpdateReplaceRecordResponse(airtableRecord);
@@ -1183,7 +1184,7 @@ namespace AirtableApiClient
         private static async Task<string> ReadResponseErrorMessage(HttpResponseMessage response,
             CancellationToken token)
         {
-            var content = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(content))
             {
@@ -1196,26 +1197,6 @@ namespace AirtableApiClient
                 return json.MessagePart.Message;
             }
             return null;
-        }
-
-
-        //----------------------------------------------------------------------------
-        //
-        // AirtableBase.CancellableReadAsStringAsync
-        //
-        // This method is needed only because Http.Content.ReadAsStringAsync() does not take any arguments in the version of .Net 5.0
-        // used in this project.
-        //
-        //----------------------------------------------------------------------------
-        private static async Task<string> CancellableReadAsStringAsync(HttpResponseMessage response, CancellationToken token)
-        {
-            if (token != default(CancellationToken))
-            {
-                // If a cancellation is request then the underlying stream will be closed by registering the Dispose() call below.
-                // when a cancellation was requested.
-                token.Register(() => response.Content.Dispose());
-            }
-            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
 
 
@@ -1305,7 +1286,7 @@ namespace AirtableApiClient
             {
                 return new AirtableCreateUpdateCommentResponse(error);
             }
-            var responseBody = await CancellableReadAsStringAsync(response, token).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var comment = JsonSerializer.Deserialize<Comment>(responseBody, JsonOptionIgnoreNullValues);
 
             return new AirtableCreateUpdateCommentResponse(comment);

--- a/AirtableApiClient/AirtableBase.cs
+++ b/AirtableApiClient/AirtableBase.cs
@@ -126,7 +126,7 @@ namespace AirtableApiClient
 
             var response = (await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false));
 
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableGetUserIdAndScopesResponse(error);
@@ -169,7 +169,7 @@ namespace AirtableApiClient
                 token
                 ).ConfigureAwait(false);
 
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableListRecordsResponse(error);
@@ -208,7 +208,7 @@ namespace AirtableApiClient
         {
             HttpResponseMessage response = await ListRecordsInternal(tableIdOrName, offset, fields, filterByFormula,
                 maxRecords, pageSize, sort, view, cellFormat, timeZone, userLocale, returnFieldsByFieldId, includeCommentCount, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableListRecordsResponse<T>(error);
@@ -240,7 +240,7 @@ namespace AirtableApiClient
             Uri uri = BuildUriForRetrieveRecord(tableIdOrName, id, cellFormat, timeZone, userLocale, returnFieldsByFieldId);
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableRetrieveRecordResponse(error);
@@ -275,7 +275,7 @@ namespace AirtableApiClient
             Uri uri = BuildUriForRetrieveRecord(tableIdOrName, id, cellFormat, timeZone, userLocale, returnFieldsByFieldId);
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableRetrieveRecordResponse<T>(error);
@@ -358,7 +358,7 @@ namespace AirtableApiClient
             string uriStr = UrlHead + Uri.EscapeDataString(tableIdOrName) + "/" + id;
             var request = new HttpRequestMessage(HttpMethod.Delete, uriStr);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableDeleteRecordResponse(error);
@@ -542,7 +542,7 @@ namespace AirtableApiClient
             }
             var request = new HttpRequestMessage(HttpMethod.Get, uriBuilder.Uri);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableListCommentsResponse(error);
@@ -615,7 +615,7 @@ namespace AirtableApiClient
             var request = new HttpRequestMessage(HttpMethod.Delete, uriStr);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
 
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableDeleteCommentResponse(error);
@@ -637,7 +637,7 @@ namespace AirtableApiClient
         {
             var request = new HttpRequestMessage(HttpMethod.Get, UrlHeadWebhooks);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableListWebhooksResponse(error);
@@ -674,7 +674,7 @@ namespace AirtableApiClient
 
             var request = new HttpRequestMessage(HttpMethod.Get, uriBuilder.Uri);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableListPayloadsResponse(error);
@@ -708,7 +708,7 @@ namespace AirtableApiClient
             var json = JsonSerializer.Serialize(urlAndSpec, JsonOptionIgnoreNullValues);
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableCreateWebhookResponse(error);
@@ -740,7 +740,7 @@ namespace AirtableApiClient
             var json = JsonSerializer.Serialize(new { enable = enable }, JsonOptionIgnoreNullValues);
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtabeEnableOrDisableWebhookNotificationsResponse(error);
@@ -767,7 +767,7 @@ namespace AirtableApiClient
             string path = UrlHeadWebhooks + "/" + webhookId + "/refresh";
             var request = new HttpRequestMessage(HttpMethod.Post, path);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtabeRefreshWebhookResponse(error);
@@ -794,7 +794,7 @@ namespace AirtableApiClient
             }
             var request = new HttpRequestMessage(HttpMethod.Delete, UrlHeadWebhooks + "/" + webhookId);
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableDeleteWebhookResponse(error);
@@ -941,7 +941,7 @@ namespace AirtableApiClient
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
 
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableCreateUpdateReplaceRecordResponse(error);
@@ -974,7 +974,7 @@ namespace AirtableApiClient
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
 
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableCreateUpdateReplaceMultipleRecordsResponse(error);
@@ -1054,8 +1054,7 @@ namespace AirtableApiClient
         // construct and return the appropriate exception based on the specified message response
         //
         //----------------------------------------------------------------------------
-        private async Task<AirtableApiException> CheckForAirtableException(HttpResponseMessage response,
-            CancellationToken token)
+        private async Task<AirtableApiException> CheckForAirtableException(HttpResponseMessage response)
         {
             switch (response.StatusCode)
             {
@@ -1081,7 +1080,7 @@ namespace AirtableApiClient
                     return (new AirtableRequestEntityTooLargeException());
 
                 case (System.Net.HttpStatusCode)422:    // There is no HttpStatusCode.InvalidRequest defined in HttpStatusCode Enumeration.
-                    var detailedErrorMessage = await ReadResponseErrorMessage(response, token).ConfigureAwait(false);
+                    var detailedErrorMessage = await ReadResponseErrorMessage(response).ConfigureAwait(false);
                     return (new AirtableInvalidRequestException(detailedErrorMessage));
 
                 case (System.Net.HttpStatusCode)429:    // There is no HttpStatusCode.TooManyRequests defined in HttpStatusCode Enumeration.
@@ -1181,8 +1180,7 @@ namespace AirtableApiClient
         // attempts to read the error message in the response body.
         //
         //----------------------------------------------------------------------------
-        private static async Task<string> ReadResponseErrorMessage(HttpResponseMessage response,
-            CancellationToken token)
+        private static async Task<string> ReadResponseErrorMessage(HttpResponseMessage response)
         {
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
@@ -1281,7 +1279,7 @@ namespace AirtableApiClient
             request.Content = new StringContent(json, Encoding.UTF8, "application/json"); ;
             var response = await httpClientWithRetries.SendAsync(request, token).ConfigureAwait(false);
 
-            AirtableApiException error = await CheckForAirtableException(response, token).ConfigureAwait(false);
+            AirtableApiException error = await CheckForAirtableException(response).ConfigureAwait(false);
             if (error != null)
             {
                 return new AirtableCreateUpdateCommentResponse(error);


### PR DESCRIPTION
AirtableBase.cs:
- Added one more ctor for AirtableBase.cs: accepts a user provided HttpClient.
- All async operations are cancellable. All async calls are updated to take a CancellationToken as an additional arg. 
- Added CancellableReadAsStringAsync().
HttpClientWithRetries.cs
- ctor accepts an optional argument: caller can provide a HttpClient
- Dispose(): does not dispose the HttpClient if it is provided by user, 
- SendAsync(): takes a CancellationToken as an additional argument