### PR TITLE
Downgraded System.Text.Json from 7.0.2 to 6.0.10 to get rid of security vulnerability warning

### DIFF
--- a/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
+++ b/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFramework>net472</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -10,15 +10,10 @@
     <NoWarn>CS8602</NoWarn>
   </PropertyGroup>
 
-  <!-- netstandard2.0: PIN EXACT versions -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+  <!-- net472: PIN EXACT versions -->
+  <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="[6.0.10]" />
     <Reference Include="System.Net.Http" Version="4.3.4"/>
-  </ItemGroup>
-
-  <!-- net6.0: leave empty (Json is inbox) -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-      <!-- intentionally empty -->
   </ItemGroup>
 
   <ItemGroup>

--- a/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
+++ b/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
@@ -22,10 +22,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <!-- Optional but recommended -->
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
+++ b/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
@@ -1,20 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!--<Nullable>disable</Nullable>-->
+    <IsTestProject>true</IsTestProject>
     <NoWarn>CS8602</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- For net472 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <!-- For net6.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Text.Json" Version="6.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
@@ -23,10 +30,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AirtableApiClient\AirtableApiClient.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 
 </Project>

--- a/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
+++ b/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
@@ -10,15 +10,15 @@
     <NoWarn>CS8602</NoWarn>
   </PropertyGroup>
 
-  <!-- For net472 -->
+  <!-- netstandard2.0: PIN EXACT versions -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
-    <Reference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.Json" Version="[6.0.10]" />
+    <Reference Include="System.Net.Http" Version="4.3.4"/>
   </ItemGroup>
 
-  <!-- For net6.0 -->
+  <!-- net6.0: leave empty (Json is inbox) -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
+      <!-- intentionally empty -->
   </ItemGroup>
 
   <ItemGroup>

--- a/AirtableApiClient.Tests/AtApiClientTests.cs
+++ b/AirtableApiClient.Tests/AtApiClientTests.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text.Json.Serialization;
+using System.Net.Http;
 
 
 namespace AirtableApiClient.Tests
@@ -12,15 +13,15 @@ namespace AirtableApiClient.Tests
     // annotation; see JsonProperty("On Display?")] below as an example.
     public class Artist
     {
-        public string Name { get; set;}
-        public List<AirtableAttachment> Attachments { get; set;}
-        public string Bio { get; set;}
+        public string Name { get; set; } = string.Empty;
+        public List<AirtableAttachment>? Attachments { get; set; }
+        public string? Bio { get; set;}
 
         [JsonPropertyName("On Display?")]
         public bool OnDisplay { get; set;}
 
-        public List<string> Collection { get; set;}
-        public List<string> Genre { get; set;}
+        public List<string>? Collection { get; set;}
+        public List<string>? Genre { get; set;}
     }
 
 
@@ -39,9 +40,9 @@ namespace AirtableApiClient.Tests
         const string API_KEY = "key1234567890ABCD";                                 // fake airtable api key for tests
         readonly string BASE_URL = $"https://api.airtable.com/v0/{APPLICATION_ID}/{Uri.EscapeDataString(TABLE_NAME)}";
 
-        static private AirtableBase airtableBase;
-        private FakeResponseHandler fakeResponseHandler;
-        private HttpResponseMessage fakeResponse;
+        static private AirtableBase? airtableBase;
+        private FakeResponseHandler? fakeResponseHandler;
+        private HttpResponseMessage? fakeResponse;
 
         //private readonly string UrlHead = "https://api.airtable.com/v0/";
         private readonly string UrlHeadWebhooks = "https://api.airtable.com/v0/" + ("bases/" + APPLICATION_ID + "/webhooks");
@@ -405,9 +406,9 @@ namespace AirtableApiClient.Tests
             Assert.IsTrue(response.Record.Id == MIYA_ANDO_RECORD_ID);
             Assert.IsTrue(response.Record.GetField<string>("fldSAUw6qVy9NzXzF") == "Miya Ando");
 
-            object collectionObject = response.Record.GetField("fldE0muAk6ejOkkKa");
-
-            string collectionString = collectionObject.ToString();
+            object? collectionObject = response.Record.GetField("fldE0muAk6ejOkkKa");
+            Assert.IsNotNull(collectionObject);
+            string? collectionString = collectionObject.ToString();
             Console.WriteLine(collectionString);
             Assert.IsTrue(collectionString == "Post-minimalism, Color Field");
         }
@@ -765,13 +766,13 @@ namespace AirtableApiClient.Tests
                     fakeResponse,
                     bodyText);
 
-            string errorMessage = null;
+            string? errorMessage = null;
             IdFields[] idFields = new IdFields[1];
             idFields[0] = new IdFields("reczQzLFP6t6HWMs0");
             idFields[0].AddField("On Display?", true);
             Task<AirtableCreateUpdateReplaceMultipleRecordsResponse> task = airtableBase.UpdateMultipleRecords(TABLE_NAME, idFields);
             var response = await task;
-            AirtableRecord[] records = null;
+            AirtableRecord[]? records = null;
             if (!response.Success)
             {
                 if (response.AirtableApiError is AirtableApiException)
@@ -822,13 +823,13 @@ namespace AirtableApiClient.Tests
                 fakeResponse,
                 bodyText);
 
-            string errorMessage = null;
+            string? errorMessage = null;
             IdFields[] idFields = new IdFields[1];
             idFields[0] = new IdFields("reczQzLFP6t6HWMs0");
             idFields[0].AddField("Name", "Auguste Rodin");
             Task<AirtableCreateUpdateReplaceMultipleRecordsResponse> task = airtableBase.ReplaceMultipleRecords(TABLE_NAME, idFields);
             var response = await task;
-            AirtableRecord[] records = null;
+            AirtableRecord[]? records = null;
             if (!response.Success)
             {
                 if (response.AirtableApiError is AirtableApiException)
@@ -969,7 +970,7 @@ namespace AirtableApiClient.Tests
                 fakeResponse,
                 bodyText);
 
-            string errorMessage = null;
+            string? errorMessage = null;
 
             IdFields[] idFields = new IdFields[2];
             idFields[0] = new IdFields(idMonet);
@@ -979,7 +980,7 @@ namespace AirtableApiClient.Tests
             idFields[1] = new IdFields(idVanGogh);
             idFields[1].AddField("Name", "Vincent VanGogh replaced");
 
-            AirtableRecord[] records = null;
+            AirtableRecord[]? records = null;
             Task<AirtableCreateUpdateReplaceMultipleRecordsResponse> task = airtableBase.ReplaceMultipleRecords(TABLE_NAME, idFields);
             var response = await task;
 
@@ -1046,7 +1047,8 @@ namespace AirtableApiClient.Tests
             Assert.IsTrue(response.Records.Count > 0);
             var record = response.Records[0];                // We knew this is the record for "Al Held"
             string fieldIdOfFieldName = "fldSAUw6qVy9NzXzF";    // We also knew this is the field ID for "Al Held"
-            string artistName = record.GetField<string>(fieldIdOfFieldName);
+            string? artistName = record.GetField<string>(fieldIdOfFieldName);
+            Assert.IsNotNull(artistName);
             Assert.IsTrue(artistName == "Al Held");
         }
 
@@ -1120,7 +1122,8 @@ namespace AirtableApiClient.Tests
             Assert.IsNotNull(records);
             foreach (var record in records)
             {
-                string bankName = record.Fields["Bank Name"].ToString();
+                string? bankName = record.Fields["Bank Name"].ToString();
+                Assert.IsNotNull(bankName);
                 record.Fields["Bank Name"] = bankName + "Updated";
             }
 
@@ -1168,7 +1171,8 @@ namespace AirtableApiClient.Tests
             Assert.IsNotNull(records);
             foreach (var record in records)
             {
-                string bankName = record.Fields["Bank Name"].ToString();
+                string? bankName = record.Fields["Bank Name"].ToString();
+                Assert.IsNotNull(bankName);
                 record.Fields["Bank Name"] = bankName + "Replaced";
                 record.Fields.Remove("Bio");
             }
@@ -1224,11 +1228,12 @@ namespace AirtableApiClient.Tests
 
             Task<AirtableCreateUpdateReplaceMultipleRecordsResponse> task = airtableBase.CreateMultipleRecords(TABLE_NAME, fields, true);
             var response = await task;
-            string renoirId = null;
-            string manetId = null;
+            string? renoirId = null;
+            string ?manetId = null;
             foreach (var record in response.Records)
             {
-                string name = record.GetField<string>("Name");
+                string? name = record.GetField<string>("Name");
+                Assert.IsNotNull(name);
                 if (name == "Pierre-Auguste Renoir")
                 {
                     renoirId = record.Id;
@@ -1539,7 +1544,7 @@ namespace AirtableApiClient.Tests
                     fakeResponse,
                     bodyText);
 
-            string errorMessage = null;
+            string? errorMessage = null;
             var records = new List<AirtableRecord>();
 
             Task<ListAllRecordsTestResponse> task = ListAllRecords();
@@ -1656,9 +1661,9 @@ namespace AirtableApiClient.Tests
         [TestMethod]
         public async Task TzGAtApiClientListCommentsTest()
         {
-            string offset = null;
+            string? offset = null;
             Task<AirtableListCommentsResponse> task;
-            AirtableListCommentsResponse response = null;
+            AirtableListCommentsResponse? response = null;
 
             fakeResponse.Content = new StringContent
                 ("{\"comments\":[{\"id\":\"com8pc4Ht1i4CkPM5\",\"author\":{\"id\":\"usrBw9fdcVFbu7ug9\",\"email\":\"ngocnicholas@gmail.com\",\"name\":\"Ngoc Nicholas\"},\"text\":\"Hello World @[usrvQIoafw4agP8m3] @[usrBw9fdcVFbu7ug9]\",\"createdTime\":\"2023-03-01T00:14:37.000Z\",\"lastUpdatedTime\":null,\"mentioned\":{\"usrvQIoafw4agP8m3\":{\"type\":\"user\",\"id\":\"usrvQIoafw4agP8m3\",\"displayName\":\"Ngoc2 Nicholas\",\"email\":\"ngocnicholas@yahoo.com\"},\"usrBw9fdcVFbu7ug9\":{\"type\":\"user\",\"id\":\"usrBw9fdcVFbu7ug9\",\"displayName\":\"Ngoc Nicholas\",\"email\":\"ngocnicholas@gmail.com\"}}},{\"id\":\"comThy6KTVRbi4SIa\",\"author\":{\"id\":\"usrBw9fdcVFbu7ug9\",\"email\":\"ngocnicholas@gmail.com\",\"name\":\"Ngoc Nicholas\"},\"text\":\"@[usrBw9fdcVFbu7ug9] and @[usrvQIoafw4agP8m3]. Also @[usr01234567891234]\",\"createdTime\":\"2023-02-28T22:25:24.000Z\",\"lastUpdatedTime\":\"2023-03-01T00:56:05.000Z\",\"mentioned\":{\"usrBw9fdcVFbu7ug9\":{\"type\":\"user\",\"id\":\"usrBw9fdcVFbu7ug9\",\"displayName\":\"Ngoc Nicholas\",\"email\":\"ngocnicholas@gmail.com\"},\"usrvQIoafw4agP8m3\":{\"type\":\"user\",\"id\":\"usrvQIoafw4agP8m3\",\"displayName\":\"Ngoc2 Nicholas\",\"email\":\"ngocnicholas@yahoo.com\"}}}],\"offset\":\"MTk1MTE0Mg==\"}");
@@ -1678,7 +1683,7 @@ namespace AirtableApiClient.Tests
                 if (response.Comments.Length > 0)     // This guy has 3 comments and all of them have @[] patterns
                 {
                     Assert.IsTrue(response.Comments.Length == 2 || response.Comments.Length == 1);
-                    string textWithUserNames = null;
+                    string? textWithUserNames = null;
                     foreach (Comment comment in response.Comments)
                     {
                         // Each comment has its own Mentioned which is Dictionary<string, UserMentioned/UserGroupMentioned/UserEmail>
@@ -2186,10 +2191,10 @@ namespace AirtableApiClient.Tests
             Assert.IsNotNull(attListFromRecordCreated);
             Assert.IsTrue(attListFromRecordCreated.Count() == 2);
 
-            List<string> genre = jony.Genre;
+            List<string>? genre = jony.Genre;
             Assert.IsTrue(genre[0].Equals(Jony.Genre[0]));
 
-            List<string> coll = jony.Collection;
+            List<string>? coll = jony.Collection;
             Assert.IsTrue(coll[0].Equals("reccV1ddwIspBOe4O")); // reccV1ddwIspBOe4O is the recprd ID of "Scupture" in the Collections table
         }
 
@@ -2292,7 +2297,7 @@ namespace AirtableApiClient.Tests
             fakeResponse,
             null);
 
-            string errorMessage = null;
+            string? errorMessage = null;
             string idJony2 = "rec8vJPDc7Seqekbi";
             string idJony3 = "recPDSfwdOECYtod5";
             if (!string.IsNullOrEmpty(idJony2) && !string.IsNullOrEmpty(idJony3))
@@ -2366,21 +2371,21 @@ namespace AirtableApiClient.Tests
 
 
         private async Task<ListAllRecordsTestResponse> ListAllRecords(
-            IEnumerable<string> fields = null,
-            string filterByFormula = null,
+            IEnumerable<string>? fields = null,
+            string? filterByFormula = null,
             int? maxRecords = null,
             int? pageSize = null,
-            IEnumerable<Sort> sort = null,
-            string view = null,
-            string cellFormat = null,
-            string timeZone = null,
-            string userLocale = null,
+            IEnumerable<Sort>? sort = null,
+            string? view = null,
+            string? cellFormat = null,
+            string? timeZone = null,
+            string? userLocale = null,
             bool returnFieldsByFieldId = false,
             bool includeCommentCount = false,
             CancellationToken token = default(CancellationToken))
         {
-            string offset = null;
-            string errorMessage = null;
+            string? offset = null;
+            string? errorMessage = null;
             var records = new List<AirtableRecord>();
             try
             {
@@ -2423,22 +2428,21 @@ namespace AirtableApiClient.Tests
 
 
         private async Task<ListAllRecordsTestResponse<T>> ListAllRecords<T>(
-        IEnumerable<string> fields = null, 
-        //string[] fields = null,
-        string filterByFormula = null,
+        IEnumerable<string>? fields = null, 
+        string? filterByFormula = null,
         int? maxRecords = null,
         int? pageSize = null,
-        IEnumerable<Sort> sort = null,
-        string view = null,
-        string cellFormat = null,
-        string timeZone = null,
-        string userLocale = null,
+        IEnumerable<Sort>? sort = null,
+        string? view = null,
+        string? cellFormat = null,
+        string? timeZone = null,
+        string? userLocale = null,
         bool returnFieldsByFieldId = false,
         bool includeCommentCount = false,
         CancellationToken token = default(CancellationToken))
         {
-            string offset = null;
-            string errorMessage = null;
+            string? offset = null;
+            string? errorMessage = null;
             var records = new List<AirtableRecord<T>>();
             try
             {
@@ -2608,8 +2612,8 @@ namespace AirtableApiClient.Tests
             {
                 foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(obj))
                 {
-                    string name = descriptor.Name;
-                    object value = descriptor.GetValue(obj);
+                    string? name = descriptor.Name;
+                    object? value = descriptor.GetValue(obj);
                     Console.WriteLine("{0}={1}", name, value);
                 }
             }

--- a/AirtableApiClient.Tests/FakeResponseHandler.cs
+++ b/AirtableApiClient.Tests/FakeResponseHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,7 +55,7 @@ namespace AirtableApiClient.Tests
                     }
                 }
             }
-            return new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = request };
+            return new HttpResponseMessage(System.Net.HttpStatusCode.NotFound) { RequestMessage = request };
         }
 
 #if false

--- a/AirtableApiClient/AirtableApiClient.csproj
+++ b/AirtableApiClient/AirtableApiClient.csproj
@@ -23,12 +23,9 @@
   <!-- <PackageLicenseFile>LICENSE</PackageLicenseFile> -->
   <PackageTags>Airtable database spreadsheet organize Kanban API</PackageTags>
   <PackageReleaseNotes>
-[docs] Upsert #85
-- Update Airtable wiki documents
-[feat] Unable to create mock tests due to internal sets #90
-- all internal sets have been changed to public
-[feat] Allow serializing T to create/update/replace record #92
-- This feature is added for Create or Replace record(s) but not for Update record(s).
+      System.Text.Json 7.0.2 has been downgraded to 6.0.10 fo fix the 2 problems below:
+      - System.Text.Json 7.0 causes problems for .net 6.0 consumers (#73)
+      - Security vulnarability in System.Text.Json 7.0.2
   </PackageReleaseNotes>
   <Description>AirtableApiClient is the C-Sharp client of the public APIs of Airtable. It facilitates the usage of Airtable APIs without having to worry about interfacing with raw HTTP.</Description>
   <RepositoryUrl>https://github.com/ngocnicholas/airtable.net</RepositoryUrl>
@@ -43,8 +40,8 @@
       <PackageLicenseFile>LICENSE</PackageLicenseFile>
       <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
       <Version>$(Version)</Version>
-      <AssemblyVersion>1.6.0</AssemblyVersion>
-      <FileVersion>1.6.0</FileVersion>
+      <AssemblyVersion>1.7.0</AssemblyVersion>
+      <FileVersion>1.7.0</FileVersion>
       <PackageReadmeFile>README.md</PackageReadmeFile>
       <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
   </PropertyGroup>

--- a/AirtableApiClient/AirtableApiClient.csproj
+++ b/AirtableApiClient/AirtableApiClient.csproj
@@ -58,13 +58,15 @@
     <None Remove="readme.txt" />
   </ItemGroup>
 
-  <!-- For netstandard2.0 -->
+  <!-- netstandard2.0: PIN EXACT versions -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="[6.0.10]" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="[6.0.0]" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="[6.0.0]" />
   </ItemGroup>
 
-  <!-- For .NET 6.0 -->
+  <!-- net6.0: leave empty (Json is inbox) -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
+    <!-- intentionally empty -->
   </ItemGroup>
 </Project>

--- a/AirtableApiClient/AirtableApiClient.csproj
+++ b/AirtableApiClient/AirtableApiClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <ApplicationIcon />
     <Win32Resource />
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  <!--AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath -->
   <PackageId>Airtable</PackageId>
   <Title>Airtable Api Client</Title>
   <Authors>Ngoc Nicholas</Authors>
@@ -58,8 +58,13 @@
     <None Remove="readme.txt" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- For netstandard2.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 
+  <!-- For .NET 6.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Text.Json" Version="6.0.5" />
+  </ItemGroup>
 </Project>

--- a/AirtableApiClient/AirtableApiClient.csproj
+++ b/AirtableApiClient/AirtableApiClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <ApplicationIcon />
     <Win32Resource />
@@ -49,21 +49,14 @@
   <ItemGroup>
       <None Include="..\LICENSE" Pack="true" PackagePath="" />
       <None Include="..\README.md" Pack="true" PackagePath="" />
+      <None Remove="readme.txt" />
   </ItemGroup>
 
+  <!-- PIN EXACT versions -->
   <ItemGroup>
-    <None Remove="readme.txt" />
-  </ItemGroup>
-
-  <!-- netstandard2.0: PIN EXACT versions -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="[6.0.10]" />
     <PackageReference Include="System.Text.Encodings.Web" Version="[6.0.0]" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="[6.0.0]" />
   </ItemGroup>
 
-  <!-- net6.0: leave empty (Json is inbox) -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <!-- intentionally empty -->
-  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Airtable by consuming what Airtable public APIs have to offer programmatically s
 Update Record, Replace Record, Delete Record.
 
 # Installation
-Install the latest nuget package Airtable.1.6.0.nupkg
+Install the latest nuget package Airtable.1.7.0.nupkg
 
 ## Requirements
 

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,0 +1,18 @@
+<RunSettings>
+  <RunConfiguration>
+    <!-- Force 64-bit test host -->
+    <TargetPlatform>x64</TargetPlatform>
+
+    <!-- Avoid AppDomain issues when mixing .NET Framework & .NET Core -->
+    <DisableAppDomain>true</DisableAppDomain>
+
+    <!-- Only used by .NET Core tests; points directly to .NET 6 runtime -->
+    <TestHostPath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.36</TestHostPath>
+  </RunConfiguration>
+
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" enabled="false" />
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/testEnvironments.json
+++ b/testEnvironments.json
@@ -1,0 +1,17 @@
+﻿{
+  "version": "1",
+  "environments": [
+    // See https://aka.ms/remotetesting for more details
+    // about how to configure remote environments.
+    //{
+    //  "name": "WSL Ubuntu",
+    //  "type": "wsl",
+    //  "wslDistribution": "Ubuntu"
+    //},
+    //{
+    //  "name": "Docker dotnet/sdk",
+    //  "type": "docker",
+    //  "dockerImage": "mcr.microsoft.com/dotnet/sdk"
+    //}
+  ]
+}


### PR DESCRIPTION
Downgraded System.Text.Json from 7.0.2 to 6.0.10 to fix 2 problems:
- get rid of security vulnerability warning
- Fixed problems introduced by System.Text.Json 7.0.2 for a net6.0 user.
Fixed all build warnings.