### PR TITLE
Add generic Update overloads with clear-field support (fixes #103)

### DIFF
--- a/AirtableApiClient.Tests/AtApiClientTests.cs
+++ b/AirtableApiClient.Tests/AtApiClientTests.cs
@@ -2346,6 +2346,120 @@ namespace AirtableApiClient.Tests
 
         }
 
+
+        //----------------------------------------------------------------------------
+        //
+        // AtApiClientTests.TzU1AtApiClientUpdateRecordGeneric
+        // Update a single record of type T using the typed/generic API.
+        // Null properties are dropped (field left untouched), so this verifies the
+        // normal PATCH path leaves unset fields alone.
+        //
+        //----------------------------------------------------------------------------
+        [TestMethod]
+        public async Task TzU1AtApiClientUpdateRecordGeneric()
+        {
+            fakeResponse.Content = new StringContent
+                ("{\"id\":\"recmzcnJeyGDsX00T\",\"createdTime\":\"2025-08-03T05:07:08.000Z\",\"fields\":{\"Name\":\"Jony Updated\",\"On Display?\":true}}");
+
+            string jonyRecordId = "recmzcnJeyGDsX00T";
+
+            // Bio is null on the record, so it must NOT appear in the request body.
+            string bodyText = "{\"fields\":{\"Name\":\"Jony Updated\",\"On Display?\":true},\"typecast\":false}";
+
+            fakeResponseHandler.AddFakeResponse(
+                        BASE_URL + "/" + jonyRecordId + "/",
+                        new HttpMethod("PATCH"),
+                        fakeResponse,
+                        bodyText);
+
+            Artist jony = new Artist();
+            jony.Name = "Jony Updated";
+            jony.OnDisplay = true;
+
+            Task<AirtableCreateReplaceRecordGenericResponse<Artist>> task = airtableBase.UpdateRecordGeneric<Artist>(TABLE_NAME, jony, jonyRecordId);
+            var response = await task;
+
+            Assert.IsTrue(response.Success);
+            Assert.IsTrue(response.Record!.Fields!.Name == "Jony Updated");
+        }
+
+
+        //----------------------------------------------------------------------------
+        //
+        // AtApiClientTests.TzU2AtApiClientUpdateRecordGenericClearField
+        // Update a single record of type T and clear a cell via fieldsToClear.
+        // Verifies the explicit null is serialized so Airtable clears the field.
+        //
+        //----------------------------------------------------------------------------
+        [TestMethod]
+        public async Task TzU2AtApiClientUpdateRecordGenericClearField()
+        {
+            fakeResponse.Content = new StringContent
+                ("{\"id\":\"recmzcnJeyGDsX00T\",\"createdTime\":\"2025-08-03T05:07:08.000Z\",\"fields\":{\"Name\":\"Jony Updated\",\"On Display?\":true}}");
+
+            string jonyRecordId = "recmzcnJeyGDsX00T";
+
+            // "Bio" is requested to be cleared, so it must be sent as an explicit null.
+            string bodyText = "{\"fields\":{\"Name\":\"Jony Updated\",\"On Display?\":true,\"Bio\":null},\"typecast\":false}";
+
+            fakeResponseHandler.AddFakeResponse(
+                        BASE_URL + "/" + jonyRecordId + "/",
+                        new HttpMethod("PATCH"),
+                        fakeResponse,
+                        bodyText);
+
+            Artist jony = new Artist();
+            jony.Name = "Jony Updated";
+            jony.OnDisplay = true;
+            jony.Bio = null;        // null property would normally be dropped; fieldsToClear forces it through
+
+            Task<AirtableCreateReplaceRecordGenericResponse<Artist>> task =
+                airtableBase.UpdateRecordGeneric<Artist>(TABLE_NAME, jony, jonyRecordId, fieldsToClear: new[] { "Bio" });
+            var response = await task;
+
+            Assert.IsTrue(response.Success);
+            Assert.IsTrue(response.Record!.Fields!.Name == "Jony Updated");
+        }
+
+
+        //----------------------------------------------------------------------------
+        //
+        // AtApiClientTests.TzU3AtApiClientUpdateMultipleRecordsGenericClearField
+        // Update multiple records of type T and clear a cell on every record.
+        //
+        //----------------------------------------------------------------------------
+        [TestMethod]
+        public async Task TzU3AtApiClientUpdateMultipleRecordsGenericClearField()
+        {
+            fakeResponse.Content = new StringContent
+                ("{\"records\":[{\"id\":\"rec8vJPDc7Seqekbi\",\"createdTime\":\"2025-08-03T23:50:36.000Z\",\"fields\":{\"Name\":\"Jony2 Again\"} },{\"id\":\"recPDSfwdOECYtod5\",\"createdTime\":\"2025-08-03T23:50:36.000Z\",\"fields\":{\"Name\":\"Jony3 Again\"} }]}");
+
+            // "Bio" must be sent as an explicit null for every record in the batch.
+            string bodyText = "{\"records\":[{\"id\":\"rec8vJPDc7Seqekbi\",\"fields\":{\"Name\":\"Jony2 Again\",\"On Display?\":false,\"Bio\":null}},{\"id\":\"recPDSfwdOECYtod5\",\"fields\":{\"Name\":\"Jony3 Again\",\"On Display?\":false,\"Bio\":null}}],\"typecast\":false,\"returnFieldsByFieldId\":false}";
+
+            fakeResponseHandler.AddFakeResponse(
+                BASE_URL + "/",
+                new HttpMethod("PATCH"),
+                fakeResponse,
+                bodyText);
+
+            string[] ids = new string[] { "rec8vJPDc7Seqekbi", "recPDSfwdOECYtod5" };
+
+            Artist[] artists = new Artist[2];
+            artists[0] = new Artist { Name = "Jony2 Again" };
+            artists[1] = new Artist { Name = "Jony3 Again" };
+
+            Task<AirtableCreateReplaceMultipleRecordsGenericResponse<Artist>> task =
+                airtableBase.UpdateMultipleRecordsGeneric<Artist>(TABLE_NAME, artists, ids, fieldsToClear: new[] { "Bio" });
+            var response = await task;
+
+            Assert.IsTrue(response.Success);
+            AirtableRecord<Artist>[]? records = response.Records;
+            Assert.IsNotNull(records);
+            Assert.IsTrue(records!.Length == 2);
+        }
+
+
         [TestMethod]
         public async Task TzVAtApiClientListBases()
         {

--- a/AirtableApiClient/AirtableBase.cs
+++ b/AirtableApiClient/AirtableBase.cs
@@ -473,6 +473,32 @@ namespace AirtableApiClient
 
         //----------------------------------------------------------------------------
         //
+        // AirtableBase.UpdateRecordGeneric<T>
+        //
+        // Called to update a record with the specified ID and of type T in the specified table.
+        // Only the fields present on the record are updated; null properties are left untouched.
+        // To clear a cell, list its field name (as it appears in the serialized JSON) in fieldsToClear.
+        //
+        //----------------------------------------------------------------------------
+        public async Task<AirtableCreateReplaceRecordGenericResponse<T>> UpdateRecordGeneric<T>(
+            string tableIdOrName,
+            T record,
+            string recordId,
+            bool typecast = false,
+            string[]? fieldsToClear = null,
+            CancellationToken token = default(CancellationToken))
+        {
+            if (string.IsNullOrEmpty(UrlHead))
+            {
+                throw new InvalidOperationException("Must call SetBaseId() to set Base ID before calling this API");
+            }
+
+            return await (CreateReplaceRecordGeneric<T>(tableIdOrName, record, new HttpMethod("PATCH"), recordId, typecast, fieldsToClear, token).ConfigureAwait(false));
+        }
+
+
+        //----------------------------------------------------------------------------
+        //
         // AirtableBase.ReplaceRecord
         //
         // Called to replace a record with the specified ID in the specified table using jsoncnotent .
@@ -513,7 +539,7 @@ namespace AirtableApiClient
                 throw new InvalidOperationException("Must call SetBaseId() to set Base ID before calling this API");
             }
 
-            return await (CreateReplaceRecordGeneric<T>(tableIdOrName, record, HttpMethod.Put, recordId, typecast, token)).ConfigureAwait(false);
+            return await (CreateReplaceRecordGeneric<T>(tableIdOrName, record, HttpMethod.Put, recordId, typecast, token: token)).ConfigureAwait(false);
         }
 
 
@@ -691,6 +717,34 @@ namespace AirtableApiClient
             IdFields[] idFields = ConvertAirtableRecordsToIdFields(records, performUpsert != null);
             var json = ReplaceUpdateMultipleRecordsInternal(idFields, typecast, returnFieldsByFieldId, performUpsert);
             return await (CreateUpdateReplaceMultipleRecords(tableIdOrName, new HttpMethod("PATCH"), json, token)).ConfigureAwait(false);
+        }
+
+
+        //----------------------------------------------------------------------------
+        //
+        // AirtableBase.UpdateMultipleRecordsGeneric<T>
+        //
+        // Called to update multiple records of type T with the specified IDs in the specified table.
+        // Only the fields present on each record are updated; null properties are left untouched.
+        // To clear a cell, list its field name (as it appears in the serialized JSON) in fieldsToClear;
+        // the same fieldsToClear set is applied to every record in the batch.
+        //
+        //----------------------------------------------------------------------------
+        public async Task<AirtableCreateReplaceMultipleRecordsGenericResponse<T>> UpdateMultipleRecordsGeneric<T>(
+            string tableIdOrName,
+            T[] records,
+            string[] ids,
+            bool typecast = false,
+            bool returnFieldsByFieldId = false,
+            string[]? fieldsToClear = null,
+            CancellationToken token = default(CancellationToken))
+        {
+            if (string.IsNullOrEmpty(UrlHead))
+            {
+                throw new InvalidOperationException("Must call SetBaseId() to set Base ID before calling this API");
+            }
+
+            return await (CreateReplaceMultipleRecordsGeneric<T>(tableIdOrName, records, new HttpMethod("PATCH"), ids, typecast, returnFieldsByFieldId, token, fieldsToClear).ConfigureAwait(false));
         }
 
 
@@ -1342,14 +1396,16 @@ namespace AirtableApiClient
             string tableIdOrName,
             T record,
             HttpMethod httpMethod,
-            string? recordId = null, // only used by Replace
+            string? recordId = null, // only used by Replace and Update
             bool typecast = false,
+            string[]? fieldsToClear = null,
             CancellationToken token = default(CancellationToken))
         {
             TableIdOrNameCheck(tableIdOrName);
 
             string json = JsonSerializer.Serialize(record, JsonOptionIgnoreNullValues);
             var fields = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+            AddFieldsToClear(fields!, fieldsToClear);
             json = JsonSerializer.Serialize(new { fields = fields, typecast = typecast }, JsonOptionIgnoreNullValues);
 
             string uriStr = UrlHead + Uri.EscapeDataString(tableIdOrName) + "/";
@@ -1384,15 +1440,20 @@ namespace AirtableApiClient
             string[]? ids,
             bool typecast,
             bool returnFieldsByFieldId,
-            CancellationToken token)
+            CancellationToken token,
+            string[]? fieldsToClear = null)
         {
             ArgsCheck(tableIdOrName, records, method, ids);
 
             // Convert records into a list of Dicionaries
             string json = JsonSerializer.Serialize(records, JsonOptionIgnoreNullValues);
             var fields = JsonSerializer.Deserialize<List<Dictionary<string, object>>>(json);
+            foreach (var record in fields!)
+            {
+                AddFieldsToClear(record, fieldsToClear);
+            }
 
-            if (method == HttpMethod.Put)   // Replacing multiple records? Airtable requires an IdFields[]
+            if (method != HttpMethod.Post)   // Replacing (PUT) or Updating (PATCH) multiple records? Airtable requires an IdFields[]
             {
                 // Combine the 2 arrays ids and fields into one IdFields[].
                 IdFields[] idFields = ids!.Zip(fields!, (id, fields) => new IdFields
@@ -1463,12 +1524,40 @@ namespace AirtableApiClient
                 throw new ArgumentException(String.Format("Number of records must be >0 && <= {0}", MAX_RECORD_OPERATION_SIZE));
             }
 
-            if (method == HttpMethod.Put)   // For Replace operations
+            if (method != HttpMethod.Post)   // For Replace (PUT) and Update (PATCH) operations
             {
                 if (ids == null || records.Length != ids.Length)
                 {
-                    throw new ArgumentException(String.Format("Number of records to be replaced must be >0 && <= {0} and equal to the number of IDs", MAX_RECORD_OPERATION_SIZE));
+                    throw new ArgumentException(String.Format("Number of records to be replaced/updated must be >0 && <= {0} and equal to the number of IDs", MAX_RECORD_OPERATION_SIZE));
                 }
+            }
+        }
+
+
+        //----------------------------------------------------------------------------
+        //
+        // AirtableBase.AddFieldsToClear
+        //
+        // Insert an explicit null value for each field name in fieldsToClear so that the
+        // field gets cleared in Airtable. Serializing a typed record drops null properties
+        // (DefaultIgnoreCondition.WhenWritingNull), but null *dictionary* values are kept,
+        // so injecting them here lets callers clear specific cells on the typed/generic path.
+        //
+        //----------------------------------------------------------------------------
+        private static void AddFieldsToClear(Dictionary<string, object> fields, string[]? fieldsToClear)
+        {
+            if (fieldsToClear == null)
+            {
+                return;
+            }
+
+            foreach (var fieldName in fieldsToClear)
+            {
+                if (string.IsNullOrEmpty(fieldName))
+                {
+                    throw new ArgumentException("Field names in fieldsToClear cannot be null or empty", "fieldsToClear");
+                }
+                fields[fieldName] = null!;
             }
         }
 


### PR DESCRIPTION
## Summary

Closes #103, and builds on the generic record support from #92.

Adds the two missing generic (typed-`T`) **Update** overloads and a way to clear specific cells on the typed path:

- `UpdateRecordGeneric<T>` — typed PATCH for a single record
- `UpdateMultipleRecordsGeneric<T>` — typed PATCH for a batch
- An optional `string[] fieldsToClear` parameter on both

Previously the generic overloads existed for Create (POST) and Replace (PUT) only — Update (PATCH) had no generic variant, so updating a record from a typed object wasn't possible without falling back to the dictionary-based `Fields`/`IdFields` API.

## Why `fieldsToClear` is needed

On PATCH you clear a cell by sending an explicit `null` (omitting the field is a no-op). But the typed/generic path serializes records with `DefaultIgnoreCondition.WhenWritingNull`, which **drops** null properties before they're sent — so a generic Update alone still couldn't clear a cell. This is the exact open question raised in #92.

The fix takes advantage of the fact that `WhenWritingNull` strips null *object properties* but keeps null *dictionary values*. The generic worker already round-trips each record through a `Dictionary<string, object>`, so `fieldsToClear` injects an explicit `null` for each requested field at that seam. The result: unset (null) properties are still left untouched, while fields named in `fieldsToClear` are sent as `null` and cleared by Airtable.

## Example

```csharp
// Clears the "Bio" cell, leaves every other field on the record untouched.
await airtableBase.UpdateRecordGeneric<MyRecord>(
    tableId, record, recordId, fieldsToClear: new[] { "Bio" });
```

## Implementation notes

- The shared multiple-records worker now routes PATCH (Update) through the same `IdFields[]` (id + fields) path as PUT (Replace); `ArgsCheck` validates the `ids` array for both verbs.
- `fieldsToClear` field names must match the **serialized JSON** field names (i.e. post-`JsonPropertyName`, as Airtable sees them).

## Tests

Added tests asserting the produced request bodies for:
- single-record generic Update without clearing (null property omitted)
- single-record generic Update with `fieldsToClear` (explicit `null` sent)
- multiple-record generic Update with `fieldsToClear` (explicit `null` sent per record)